### PR TITLE
Fixed spelling from "Recieve" to "Receive" port

### DIFF
--- a/OSCVRCWiz/VoiceWizardWindow.Designer.cs
+++ b/OSCVRCWiz/VoiceWizardWindow.Designer.cs
@@ -2896,7 +2896,7 @@
             this.label46.Name = "label46";
             this.label46.Size = new System.Drawing.Size(90, 20);
             this.label46.TabIndex = 64;
-            this.label46.Text = "Recieve Port";
+            this.label46.Text = "Receive Port";
             // 
             // button8
             // 


### PR DESCRIPTION
Checked on popular dictionary sites to verify correct spelling.

Recieve - WRONG SPELLING (no results)
https://www.dictionary.com/misspelling?term=recieve
https://www.merriam-webster.com/dictionary/recieve
https://dictionary.cambridge.org/dictionary/english/recieve

Receive - CORRECT SPELLING
https://www.dictionary.com/browse/receive
https://www.merriam-webster.com/dictionary/receive
https://dictionary.cambridge.org/dictionary/english/receive
